### PR TITLE
Fix an option conflict in the titlesec package

### DIFF
--- a/clearpath-manual.cls
+++ b/clearpath-manual.cls
@@ -21,7 +21,7 @@
 \RequirePackage{microtype}
 \RequirePackage{fontspec}
 \RequirePackage{xltxtra,xunicode}
-\RequirePackage{titlesec}
+\RequirePackage[nobottomtitles*]{titlesec}
 \RequirePackage{siunitx}
 \defaultfontfeatures{Mapping=tex-text,Scale=MatchLowercase}
 
@@ -54,7 +54,7 @@
 
 %% Set up heading
 
-\RequirePackage{titlesec}
+\RequirePackage[nobottomtitles*]{titlesec}
 \titleformat{\section}
   {\titlefont\fontsize{24pt}{6pt}\bfseries\color{orange}}{\hspace*{-12.8pt}\llap\thesection\hskip 12pt}{0pt}{\MakeUppercase}
 \titleformat{\subsection}


### PR DESCRIPTION
Errors due to inconsistent options in the titlesec package are preventing building LaTeX docs.